### PR TITLE
Implement ELPM_2, ELPM_3

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -446,13 +446,17 @@ static void do_ELPM_1(u16 instr)
 static void do_ELPM_2(u16 instr)
 {
     trace(__FUNCTION__);
-    unimplemented(__FUNCTION__);
+    u16 d = ((instr >> 4) & 0x1f);
+    Data.Reg[d] = ((u8 *)Program)[Data.Z];
+    Cycle += 3;
 }
 
 static void do_ELPM_3(u16 instr)
 {
     trace(__FUNCTION__);
-    unimplemented(__FUNCTION__);
+    u16 d = ((instr >> 4) & 0x1f);
+    Data.Reg[d] = ((u8 *)Program)[Data.Z++];
+    Cycle += 3;
 }
 
 static void do_EOR(u16 instr)


### PR DESCRIPTION
`ELPM` (Extended Load Program Memory) was implemented in its first form, which loads `Z` into `R0`, but not its second or third forms, which loads `Z` or `Z++` into `R[d]`. I implemented these functions.

![ELPM reference](https://f.cloud.github.com/assets/118362/1223015/75c4e096-270b-11e3-8d74-432497883311.png)
